### PR TITLE
mock usleep function to retun 0 on tests

### DIFF
--- a/sdk/tests/core/CMakeLists.txt
+++ b/sdk/tests/core/CMakeLists.txt
@@ -12,7 +12,7 @@ include(AddTestCMocka)
 
 # -ld link option is only available for gcc
 if(UNIT_TESTING_MOCKS)
-    set(WRAP_FUNCTIONS "-Wl,--wrap=az_platform_clock_msec -Wl,--wrap=az_http_client_send_request")
+    set(WRAP_FUNCTIONS "-Wl,--wrap=az_platform_clock_msec -Wl,--wrap=usleep -Wl,--wrap=az_http_client_send_request")
 else()
     set(WRAP_FUNCTIONS "")
 endif()

--- a/sdk/tests/core/test_az_credential_client_secret.c
+++ b/sdk/tests/core/test_az_credential_client_secret.c
@@ -3,10 +3,10 @@
 
 #include "az_test_definitions.h"
 #include <azure/core/az_credentials.h>
-#include <azure/core/internal/az_credentials_internal.h>
-#include <azure/core/internal/az_http_internal.h>
 #include <azure/core/az_http_transport.h>
 #include <azure/core/az_span.h>
+#include <azure/core/internal/az_credentials_internal.h>
+#include <azure/core/internal/az_http_internal.h>
 
 #include <stddef.h>
 
@@ -89,6 +89,7 @@ static void test_credential_client_secret(void** state)
 
 #ifdef _az_MOCK_ENABLED
     will_return_count(__wrap_az_platform_clock_msec, clock_value[i], clock_nrequests[i]);
+    will_return(__wrap_usleep, 0);
     ignore = az_http_pipeline_process(&pipeline, &request, &response);
     assert_true(az_span_is_content_equal(expected_responses[i], response._internal.http_response));
 #else // _az_MOCK_ENABLED
@@ -240,15 +241,21 @@ az_result send_request(_az_http_request const* request, az_http_response* respon
 }
 
 #ifdef _az_MOCK_ENABLED
-az_result __wrap_az_http_client_send_request(_az_http_request const* request, az_http_response* ref_response);
+az_result __wrap_az_http_client_send_request(
+    _az_http_request const* request,
+    az_http_response* ref_response);
 int64_t __wrap_az_platform_clock_msec();
+void __wrap_usleep();
 
-az_result __wrap_az_http_client_send_request(_az_http_request const* request, az_http_response* ref_response)
+az_result __wrap_az_http_client_send_request(
+    _az_http_request const* request,
+    az_http_response* ref_response)
 {
   return send_request(request, ref_response);
 }
 
 int64_t __wrap_az_platform_clock_msec() { return (int64_t)mock(); }
+void __wrap_usleep() {}
 #endif // _az_MOCK_ENABLED
 
 int test_az_credential_client_secret()

--- a/sdk/tests/core/test_az_policy.c
+++ b/sdk/tests/core/test_az_policy.c
@@ -4,9 +4,9 @@
 #include "az_test_definitions.h"
 #include <azure/core/az_credentials.h>
 #include <azure/core/az_http.h>
-#include <azure/core/internal/az_http_internal.h>
 #include <azure/core/az_http_transport.h>
 #include <azure/core/az_span.h>
+#include <azure/core/internal/az_http_internal.h>
 
 #include <setjmp.h>
 #include <stdarg.h>
@@ -241,6 +241,7 @@ void test_az_http_pipeline_policy_retry(void** state)
 
   // set clock sec required when retrying (will retry 4 times)
   will_return_count(__wrap_az_platform_clock_msec, 0, 4);
+  will_return_count(__wrap_usleep, 0, 4);
   az_http_response response;
   assert_return_code(
       az_http_pipeline_policy_retry(policies, &retry_options, &request, &response), AZ_OK);
@@ -281,6 +282,7 @@ void test_az_http_pipeline_policy_retry_with_header(void** state)
         };
 
   will_return(__wrap_az_platform_clock_msec, 0);
+  will_return(__wrap_usleep, 0);
 
   az_http_response response;
   assert_return_code(
@@ -322,6 +324,7 @@ void test_az_http_pipeline_policy_retry_with_header_2(void** state)
         };
 
   will_return(__wrap_az_platform_clock_msec, 0);
+  will_return(__wrap_usleep, 0);
 
   az_http_response response;
   assert_return_code(


### PR DESCRIPTION
Adding mock for usleep so tests don't run usleep in POSIX platform and tests takes forever or timeout on cmocka